### PR TITLE
libmaps: Depend on liboctomap-dev

### DIFF
--- a/mrpt_libmaps/package.xml
+++ b/mrpt_libmaps/package.xml
@@ -50,6 +50,7 @@
   <!--  <build_depend>libqt5-opengl-dev</build_depend> -->
   <!--  <build_depend>qtbase5-dev</build_depend> -->
 
+  <build_depend>liboctomap-dev</build_depend>
 
   <doc_depend>doxygen</doc_depend>
 


### PR DESCRIPTION
Dependency on liboctomap-dev was removed in commit e94c04e ("Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository", 2025-10-23), but libmaps needs octomap to build. Otherwise, the following error message is printed:

    /build/mrpt-build/src/mrpt/libs/maps/src/maps/COctoMap.cpp:18:10:
    fatal error: octomap/OcTree.h: No such file or directory